### PR TITLE
Editorial: Update the protocol alterations note to reflect the spec move

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -83,17 +83,17 @@ through a custom server.</p>
 
 <div class=note>
  This section replaces part of the WebSocket protocol opening handshake client requirement to
- integrate it with algorithms defined in the Fetch Standard. This way CSP, cookies, HSTS, and other
- Fetch-related protocols are handled in a single location. Ideally the RFC would be updated with
- this language, but it is never that easy. The {{WebSocket}} API, defined below, uses this language.
- [[!WSP]] [[!FETCH]]
+ integrate it with algorithms defined in <cite>Fetch</cite>. This way CSP, cookies, HSTS, and other
+ <cite>Fetch</cite>-related protocols are handled in a single location. Ideally the RFC would be
+ updated with this language, but it is never that easy. The {{WebSocket}} API, defined below, uses
+ this language. [[!WSP]] [[!FETCH]]
 
  The way this works is by replacing The WebSocket Protocol's "establish a WebSocket connection"
- algorithm with a new one that integrates with Fetch. "Establish a WebSocket connection" consists of
- three algorithms: setting up a connection, creating and transmiting a handshake request, and
- validating the handshake response. That layering is different from Fetch, which first creates a
- handshake, then sets up a connection and transmits the handshake, and finally validates the
- response. Keep that in mind while reading these alterations.
+ algorithm with a new one that integrates with <cite>Fetch</cite>. "Establish a WebSocket
+ connection" consists of three algorithms: setting up a connection, creating and transmiting a
+ handshake request, and validating the handshake response. That layering is different from
+ <cite>Fetch</cite>, which first creates a handshake, then sets up a connection and transmits the
+ handshake, and finally validates the response. Keep that in mind while reading these alterations.
 </div>
 
 

--- a/index.bs
+++ b/index.bs
@@ -83,10 +83,10 @@ through a custom server.</p>
 
 <div class=note>
  This section replaces part of the WebSocket protocol opening handshake client requirement to
- integrate it with algorithms defined in Fetch. This way CSP, cookies, HSTS, and other Fetch-related
- protocols are handled in a single location. Ideally the RFC would be updated with this language,
- but it is never that easy. The WebSocket API, defined in the HTML Standard, has been updated to use
- this language. [[!WSP]] [[!HTML]]
+ integrate it with algorithms defined in the Fetch Standard. This way CSP, cookies, HSTS, and other
+ Fetch-related protocols are handled in a single location. Ideally the RFC would be updated with
+ this language, but it is never that easy. The {{WebSocket}} API, defined below, uses this language.
+ [[!WSP]] [[!FETCH]]
 
  The way this works is by replacing The WebSocket Protocol's "establish a WebSocket connection"
  algorithm with a new one that integrates with Fetch. "Establish a WebSocket connection" consists of


### PR DESCRIPTION
The note in "WebSocket protocol alterations" mentions the `WebSocket` API being defined in HTML, and references the HTML spec but not Fetch. This change updates it to reflect its new placement in the WebSockets standard.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/websockets/8.html" title="Last updated on Dec 13, 2021, 10:28 PM UTC (b162e3f)">Preview</a> | <a href="https://whatpr.org/websockets/8/7fe0f18...b162e3f.html" title="Last updated on Dec 13, 2021, 10:28 PM UTC (b162e3f)">Diff</a>