### PR TITLE
Export terms used in whatwg/fetch

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -101,7 +101,7 @@ through a custom server.</p>
 
 <div algorithm>
 
-To <dfn id=concept-websocket-connection-obtain>obtain a WebSocket connection</dfn>, given a
+To <dfn export id=concept-websocket-connection-obtain>obtain a WebSocket connection</dfn>, given a
 |url|, run these steps:
 
 1. Let |host| be |url|'s <a for=url>host</a>.
@@ -128,7 +128,7 @@ therefore not shareable, a WebSocket connection is very close to identical to an
 
 <div algorithm>
 
-To <dfn id=concept-websocket-establish>establish a WebSocket connection</dfn>, given a
+To <dfn export id=concept-websocket-establish>establish a WebSocket connection</dfn>, given a
 |url|, |protocols|, and |client|, run these steps:
 
 1. Let |requestURL| be a copy of |url|, with its <a for=url>scheme</a> set to "`http`", if |url|'s


### PR DESCRIPTION
Export terms used in https://github.com/whatwg/fetch/pull/1366.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/websocket/9.html" title="Last updated on Dec 13, 2021, 1:46 PM UTC (4c2912f)">Preview</a> | <a href="https://whatpr.org/websockets/9/7fe0f18...4c2912f.html" title="Last updated on Dec 13, 2021, 1:46 PM UTC (4c2912f)">Diff</a>