### PR TITLE
Fix small editorial issue

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -278,7 +278,7 @@ It can have the following values:
 
  : <code>|socket|.<a method for=WebSocket>close</a>([ |code| ] [, |reason| ])</code>
  :: Closes the WebSocket connection, optionally using |code| as [=the WebSocket connection
-    close code=] and |reason| as the [=the WebSocket connection close reason=].
+    close code=] and |reason| as [=the WebSocket connection close reason=].
 
  : <code>|socket|.<a attribute for=WebSocket>url</a></code>
  :: Returns the <a lt="url">URL that was used</a> to establish the WebSocket connection.


### PR DESCRIPTION
Removing the `the the`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/websockets/32.html" title="Last updated on May 31, 2022, 5:51 AM UTC (ae784e5)">Preview</a> | <a href="https://whatpr.org/websockets/32/7f94fb9...ae784e5.html" title="Last updated on May 31, 2022, 5:51 AM UTC (ae784e5)">Diff</a>