### PR TITLE
Add WebSocket context cleanup steps to support BFCache

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -797,6 +797,25 @@ the following list:
 
 </div>
 
+<hr>
+
+If a user agent is to run the <dfn export>context cleanup steps</dfn> given a {{WebSocket}} object,
+the user agent must follow the first appropriate set of steps from the following list:
+
+<div algorithm="context cleanup steps">
+
+<dl class="switch">
+
+ : If the WebSocket connection is not yet [=established=] or the WebSocket closing handshake has
+   not yet been <a lt="the WebSocket closing handshake is started">started</a> [[!WSP]]
+ :: [=Fail the WebSocket connection=]. [[!WSP]]
+ : Otherwise
+ :: Do nothing.
+
+</dl>
+
+</div>
+
 <h2 id="acks" class="no-num">Acknowledgments</h2>
 
 Until the creation of this standard in 2021, the text here was maintained in the <a


### PR DESCRIPTION
<!--
Thank you for contributing to the WebSockets Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->
This new section is designed to be called from the [unloading document cleanup steps](https://html.spec.whatwg.org/#unloading-document-cleanup-steps) in the HTML Standard when a page is entering the Back/Forward Cache (BFCache). The corresponding changes to the HTML Standard to hook into these steps are being tracked in https://github.com/whatwg/html/pull/12349.

When a page with an active WebSocket enters the BFCache, the "fail the WebSocket connection" is invoked, causing the onerror and onclose events to be fired. [4. Feedback from the protocol](https://websockets.spec.whatwg.org/#feedback-from-the-protocol) says:

> When the WebSocket connection is closed, possibly cleanly, the user agent must queue a task to run the following substeps:

So these events will be queued and then dispatched after the page is restored from BFCache. See https://github.com/whatwg/html/issues/12085 for more detail.


- [x] At least two implementers are interested (and none opposed):
   * Chromium
   * WebKit
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://chromium-review.git.corp.google.com/c/chromium/src/+/7698838
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://issues.chromium.org/issues/467838624
   * Gecko: …
   * WebKit: …
   * Deno: …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [ ] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
